### PR TITLE
Ensure to update the given config struct on initial request

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -110,7 +110,8 @@ func (w *watcher) operate(ctx context.Context) {
 			if !ok {
 				cache[req.botType] = map[string]*file{}
 
-				files, err := w.get(ctx, req.botType)
+				var err error
+				files, err = w.get(ctx, req.botType)
 				if err != nil {
 					req.err <- err
 					continue

--- a/watcher.go
+++ b/watcher.go
@@ -279,31 +279,33 @@ type querier interface {
 //    }
 // 	}
 type query struct {
-	Repository struct {
-		Object struct {
-			Tree struct {
-				Entries []struct {
-					Name   githubv4.String
-					Object struct {
-						Blob struct {
-							Oid  githubv4.String
-							Text githubv4.String
-						} `graphql:"... on Blob"`
-					}
-				}
-			} `graphql:"... on Tree"`
-		} `graphql:"object(expression: $expression)"`
-	} `graphql:"repository(owner: $owner, name: $name)"`
+	Repository repository `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+type repository struct {
+	Object repositoryObject `graphql:"object(expression: $expression)"`
+}
+
+type repositoryObject struct {
+	Tree tree `graphql:"... on Tree"`
+}
+
+type tree struct {
+	Entries []entry
+}
+
+type entryObject struct {
+	Blob blob `graphql:"... on Blob"`
+}
+
+type blob struct {
+	Oid  githubv4.String
+	Text githubv4.String
 }
 
 type entry struct {
 	Name   githubv4.String
-	Object struct {
-		Blob struct {
-			Oid  githubv4.String
-			Text githubv4.String
-		} `graphql:"... on Blob"`
-	}
+	Object entryObject
 }
 
 type file struct {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -252,30 +252,15 @@ func TestWatcher_get(t *testing.T) {
 			t.Errorf("Expected 'expression' value of %s but was %s", e, expectedExp)
 		}
 
-		typed.Repository.Object.Tree.Entries = []struct {
-			Name   githubv4.String
-			Object struct {
-				Blob struct {
-					Oid  githubv4.String
-					Text githubv4.String
-				} `graphql:"... on Blob"`
-			}
-		}{
+		typed.Repository.Object.Tree.Entries = []entry{
 			{
 				Name: githubv4.String(fmt.Sprintf("%s%s", id, ext)),
-				Object: struct {
-					Blob struct {
-						Oid  githubv4.String
-						Text githubv4.String
-					} `graphql:"... on Blob"`
-				}{
-					Blob: struct {
-						Oid  githubv4.String
-						Text githubv4.String
-					}{
+				Object: entryObject{
+					Blob: blob{
 						Oid:  githubv4.String(oid),
 						Text: githubv4.String(text),
-					}},
+					},
+				},
 			},
 		}
 


### PR DESCRIPTION
When an interval-based synchronization with GitHub is not made yet and `watcher.Read` is called, an initial call to GitHub is made but the returned object value is not properly reflected to the internal cache.

In the below code fragment, the result of `watcher.get` is assigned to `files` variable. This assignment is meant to override the pre-declared `files` variable. However, because the assignment is done with `:=` to deal with the newly declaring `err` variable -- `files, err := w.get(ctx, req.botType)` --, pre-declared `files` is not overridden. Instead, the value is assigned to a new `files` variable with a narrower scope.
https://github.com/oklahomer/go-sarah-githubconfig/blob/cfd13245f0f0156829b85777d4f1469cdfc9bbb9/watcher.go#L109-L121

This P-R fixes that assignment so the `files` variable is overridden and makes sure the overridden value can be referred to.

The first commit, 4d15428281e2bab30224d6378e26bcbe531815b0, declares the types to make the test easier and the later commits work on the issue.